### PR TITLE
fix parentheses position

### DIFF
--- a/game-of-wines/game-of-wines.ipynb
+++ b/game-of-wines/game-of-wines.ipynb
@@ -329,7 +329,7 @@
       "Total number of wine data: 1599\n",
       "Wines with rating 7 and above: 217\n",
       "Wines with rating less than 5: 63\n",
-      "Wines with rating 5 and 6: 1599\n",
+      "Wines with rating 5 and 6: 1319\n",
       "Percentage of wines with quality 7 and above: 13.57%\n"
      ]
     },
@@ -541,7 +541,7 @@
     "n_below_5 = quality_below_5.shape[0]\n",
     "\n",
     "# Number of wines with quality rating between 5 to 6\n",
-    "quality_between_5 = data.loc[(data['quality']) >= 5 & (data['quality'] <= 6)]\n",
+    "quality_between_5 = data.loc[(data['quality'] >= 5) & (data['quality'] <= 6)]\n",
     "n_between_5 = quality_between_5.shape[0]\n",
     "\n",
     "# Percentage of wines with quality rating above 6\n",
@@ -10413,7 +10413,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
There are misplaced parentheses due to which number of wines with quality >=5 and <=6 are coming out to be 1599 which is, ofcourse incorrect.